### PR TITLE
Add redis configuration

### DIFF
--- a/helm_deploy/hmpps-resettlement-passport-person-on-probation-ui/values.yaml
+++ b/helm_deploy/hmpps-resettlement-passport-person-on-probation-ui/values.yaml
@@ -31,7 +31,7 @@ generic-service:
   # Environment variables to load into the deployment
   env:
     NODE_ENV: "production"
-    REDIS_ENABLED: "false"
+    REDIS_ENABLED: "true"
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "false"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -7,6 +7,7 @@ declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
+    tempValue: number // TODO: delete
   }
 }
 

--- a/server/routes/home/homeController.ts
+++ b/server/routes/home/homeController.ts
@@ -2,6 +2,15 @@ import { RequestHandler } from 'express'
 
 export default class HomeController {
   index: RequestHandler = async (req, res) => {
-    res.render('pages/index')
+    /**
+     * To be deleted, this code is to test the Redis session is configured correctly
+     */
+    if (!req.session.tempValue) {
+      req.session.tempValue = Math.random()
+    }
+
+    res.render('pages/index', {
+      sessionValue: req.session.tempValue,
+    })
   }
 }

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -7,9 +7,12 @@
   <div class="govuk-grid-row govuk-!-padding-bottom-8">
     <div class="govuk-grid-column-full">
 
+
       <h2 class="govuk-heading-m">
             Create a GOV.UK One Login or sign in
         </h2>
+
+      <p>Testing value for Redis configuration: {{sessionValue}}</p>
 
       <p>You'll need a GOV.UK One Login to use this service. If you do not have a GOV.UK One Login, you can create one.
         </p>


### PR DESCRIPTION
Enable redis for session management.

**Testing steps:**
- `docker-compose up -d`
- `REDIS_ENABLED=true npm run start:dev`
- take note of the random session number displayed `localhost:3000`
- stop the node server
- restart the server `REDIS_ENABLED=true npm run start:dev`
- The random number should be the same if redis is configured correctly