### PR TITLE
PLT-163 add parameters for post logout redirect

### DIFF
--- a/integration_tests/e2e/appointments.cy.ts
+++ b/integration_tests/e2e/appointments.cy.ts
@@ -1,4 +1,5 @@
 import AppointmentsPage from '../pages/appointment'
+import HomePage from '../pages/home'
 import Page from '../pages/page'
 
 context('Appointments', () => {
@@ -13,7 +14,7 @@ context('Appointments', () => {
 
   afterEach(() => {
     cy.get('[data-qa="signOut"]').click()
-    cy.contains('You have been logged out.')
+    Page.verifyOnPage(HomePage)
   })
 
   it('Should render no appointments for error responses', () => {

--- a/integration_tests/e2e/dashboard.cy.ts
+++ b/integration_tests/e2e/dashboard.cy.ts
@@ -1,4 +1,5 @@
 import DashboardPage from '../pages/dashboard'
+import HomePage from '../pages/home'
 import Page from '../pages/page'
 
 context('Dashboard', () => {
@@ -15,7 +16,7 @@ context('Dashboard', () => {
 
   afterEach(() => {
     cy.get('[data-qa="signOut"]').click()
-    cy.contains('You have been logged out.')
+    Page.verifyOnPage(HomePage)
   })
 
   it('Should render alert box for todays appointments', () => {

--- a/integration_tests/e2e/govukOneLogin.cy.ts
+++ b/integration_tests/e2e/govukOneLogin.cy.ts
@@ -44,6 +44,6 @@ context('Sign in with GOV.UK One Login', () => {
     cy.signIn()
     Page.verifyOnPage(OtpPage)
     cy.get('a.moj-sub-navigation__link[data-qa="signOut"]').click()
-    cy.contains('You have been logged out.')
+    Page.verifyOnPage(HomePage)
   })
 })

--- a/integration_tests/e2e/licenceConditions.cy.ts
+++ b/integration_tests/e2e/licenceConditions.cy.ts
@@ -1,3 +1,4 @@
+import HomePage from '../pages/home'
 import LicencePage from '../pages/licence'
 import Page from '../pages/page'
 
@@ -15,7 +16,7 @@ context('Licence conditions', () => {
 
   afterEach(() => {
     cy.get('[data-qa="signOut"]').click()
-    cy.contains('You have been logged out.')
+    Page.verifyOnPage(HomePage)
   })
 
   it('Should see licence conditions', () => {

--- a/integration_tests/e2e/otpVerification.cy.ts
+++ b/integration_tests/e2e/otpVerification.cy.ts
@@ -1,3 +1,4 @@
+import HomePage from '../pages/home'
 import OtpPage from '../pages/otp'
 import Page from '../pages/page'
 
@@ -21,7 +22,7 @@ context('OTP verification', () => {
 
   afterEach(() => {
     cy.get('[data-qa="signOut"]').click()
-    cy.contains('You have been logged out.')
+    Page.verifyOnPage(HomePage)
   })
 
   it.skip('Should not continue to Dashboard after validating OTP (invalid)', () => {

--- a/integration_tests/e2e/profile.cy.ts
+++ b/integration_tests/e2e/profile.cy.ts
@@ -1,3 +1,6 @@
+import HomePage from '../pages/home'
+import Page from '../pages/page'
+
 context('Profile', () => {
   beforeEach(() => {
     cy.task('reset')
@@ -10,7 +13,7 @@ context('Profile', () => {
 
   afterEach(() => {
     cy.get('[data-qa="signOut"]').click()
-    cy.contains('You have been logged out.')
+    Page.verifyOnPage(HomePage)
   })
 
   it('Should be able to see profile page and profile data', () => {

--- a/integration_tests/e2e/settings.cy.ts
+++ b/integration_tests/e2e/settings.cy.ts
@@ -1,3 +1,6 @@
+import HomePage from '../pages/home'
+import Page from '../pages/page'
+
 context('Settings', () => {
   beforeEach(() => {
     cy.task('reset')
@@ -10,7 +13,7 @@ context('Settings', () => {
 
   afterEach(() => {
     cy.get('[data-qa="signOut"]').click()
-    cy.contains('You have been logged out.')
+    Page.verifyOnPage(HomePage)
   })
 
   it('Should be able to see settings page and links', () => {

--- a/integration_tests/mockApis/govukOneLogin.ts
+++ b/integration_tests/mockApis/govukOneLogin.ts
@@ -164,14 +164,15 @@ const signOut = () =>
       urlPath: '/govukOneLogin/logout',
       queryParameters: {
         client_id: { equalTo: 'clientId' },
+        id_token_hint: { matches: '.*' },
+        post_logout_redirect_uri: { equalTo: 'http://localhost:3000' },
       },
     },
     response: {
-      status: 200,
+      status: 302, // Use 301 for permanent redirects
       headers: {
-        'Content-Type': 'text/html',
+        Location: 'http://localhost:3007/',
       },
-      body: '<html><body><h1>GOV.UK One Login</h1><p>You have been logged out.</p></body></html>',
     },
   })
 

--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -5,6 +5,8 @@ import { createPrivateKey } from 'crypto'
 
 import config from '../config'
 import logger from '../../logger'
+import TokenStore from '../data/tokenStore/tokenStore'
+import { createRedisClient } from '../data/redisClient'
 
 const excludedRoutes = ['/', '/cookies', '/privacy-policy']
 
@@ -56,6 +58,9 @@ async function init(): Promise<Client> {
   }
 
   const verify: StrategyVerifyCallbackUserInfo<UserinfoResponse> = (tokenSet, userInfo, done) => {
+    const tokenStore = new TokenStore(createRedisClient())
+    tokenStore.setToken(userInfo.sub, tokenSet.id_token, config.session.expiryMinutes)
+
     return done(null, userInfo)
   }
 


### PR DESCRIPTION
POST REDIRECT URI is an option we didn't use so far for One Login, so this ended up in being stuck at this screen 
without the possibility to go back to Plan Your Future.
<img width="891" alt="image" src="https://github.com/ministryofjustice/hmpps-resettlement-passport-person-on-probation-ui/assets/159039282/8d0530a6-17e3-4265-a25e-40a039160636">

Now I have configured this so we can go back to Start page

As documented here https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/log-your-users-out/#log-your-users-out-of-gov-uk-one-login