### PR TITLE
PLT-210 add signout after error page

### DIFF
--- a/integration_tests/e2e/errorPage.cy.ts
+++ b/integration_tests/e2e/errorPage.cy.ts
@@ -1,3 +1,6 @@
+import HomePage from '../pages/home'
+import Page from '../pages/page'
+
 context('Error', () => {
   beforeEach(() => {
     cy.task('reset')
@@ -8,11 +11,15 @@ context('Error', () => {
     cy.task('stubGetPopUserByUrn')
   })
 
+  afterEach(() => {
+    cy.get('[data-qa="signOut"]').click()
+    Page.verifyOnPage(HomePage)
+  })
+
   it('Should render error when a 500 response is received', () => {
     cy.task('stubGetAppointmentsError')
     cy.signIn()
     cy.visit('/appointments')
     cy.get('[data-qa="error-page-title"]').contains('Sorry, there is a problem with the service')
-    cy.visit('/sign-out')
   })
 })

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -4,6 +4,7 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
+{% include "../partials/limited-subnavigation.njk" %}
  <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-top-4" data-qa="error-page-title">Sorry, there is a problem with the service</h1>


### PR DESCRIPTION
If the user is presented with the error page they have no option to logout which is important they do, so they can close the session and start again