### PR TITLE
Plt 289 update e2e tests

### DIFF
--- a/E2E_Tests/pageObjects/completeAccountPage.ts
+++ b/E2E_Tests/pageObjects/completeAccountPage.ts
@@ -9,6 +9,7 @@ export default class CompleteAccourtPage {
   readonly enterMonth: Locator;
   readonly enterYear: Locator;
   readonly continue: Locator;
+  readonly warning: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -18,6 +19,7 @@ export default class CompleteAccourtPage {
     this.enterMonth = page.locator('//*[@id="dobMonth"]');
     this.enterYear = page.locator('//*[@id="dobYear"]');
     this.continue = page.locator('//*[@id="main-content"]/div/div/form/button');
+    this.warning = page.locator('//*[@id="main-content"]/div[1]/div/div/ul/li/a');
 
   }
 

--- a/E2E_Tests/pageObjects/navigationPage.ts
+++ b/E2E_Tests/pageObjects/navigationPage.ts
@@ -4,7 +4,7 @@ export default class NavigationPage {
   private page: Page;
 
   readonly pageHeader: Locator;
-  readonly homeLink: Locator;
+  readonly overviewLink: Locator;
   readonly appointmentsLink: Locator;
   readonly licenceConditionsLink: Locator;
   readonly profileLink: Locator;
@@ -15,7 +15,7 @@ export default class NavigationPage {
   constructor(page: Page) {
     this.page = page;
     this.pageHeader = page.locator('h1');
-    this.homeLink = page.locator('[data-qa="home-nav-link"]');
+    this.overviewLink = page.locator('[data-qa="home-nav-link"]');
     this.appointmentsLink = page.locator('[data-qa="appointments-nav-link"]');
     this.licenceConditionsLink = page.locator('[data-qa="licence-conditions-nav-link"]');
     this.profileLink = page.locator('[data-qa="profile-nav-link"]');

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -1,13 +1,14 @@
 Feature: Home
 
- @test
+
+@test
   Scenario: User Housekeeping if failure of tests
     Given the user has access to their first-time ID code
     Given the user visit plan your future
     Then delete account housekeeping
     
 
- @test
+@test
   Scenario: Full E2E registration Gov One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
@@ -16,7 +17,7 @@ Feature: Home
     Then the user deletes their Gov One Account
 
 
- @test
+@test
   Scenario: User registration to Gov One, then logs out, then logs back into complete registration then deletes account
     Given the user has access to their first-time ID code
     Given the user visit plan your future
@@ -38,7 +39,7 @@ Feature: Home
     Then the user deletes their Gov One Account after logging in
 
 
- @test 
+@test
   Scenario: User registration to Gov One, then completes PYF then logs out, then tries to re-register with Gov One
     Given the user has access to their first-time ID code
     Given the user visit plan your future
@@ -46,6 +47,27 @@ Feature: Home
     Then the user completes the account setup with first-time ID code
     Then the user Logs Out of the service
     Then they try to re-create an existing account with Gov One Login
+    Then the user deletes their Gov One Account after logging in
+
+
+@test
+  Scenario: Full E2E registration Gov One then completed PYF then delete account tries to register with same OTP NOMIS ID, requests new OTP to complete registration
+    Given the user has access to their first-time ID code
+    When the user visit plan your future
+    Then they create an account with Gov One Login
+    Then the user completes the account setup with first-time ID code
+    Then the user deletes their Gov One Account
+    Then the user revisits plan your future
+    Then the user will be still logged into current session so Logs Out of the service
+    Then they create an account with Gov One Login
+    Then the user completes the account setup with expired first-time ID code
+    Then the user Logs Out of the service
+    Then the user requests for their first-time ID code
+    Then the user revisits plan your future
+    Then the user logs into their account who has not completed account setup
+    Then the user completes the account setup with first-time ID code
+    Then the user deletes their Gov One Account after logging in
+
 
 
   

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -1,6 +1,13 @@
 Feature: Home
 
   @test
+  Scenario: User Housekeeping if failure of tests
+    Given the user has access to their first-time ID code
+    Given the user visit plan your future
+    Then delete account housekeeping
+    
+
+  @test
   Scenario: Full E2E registration Gov One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
@@ -30,9 +37,6 @@ Feature: Home
     Then the user logs into their account who has completed account setup
     Then the user deletes their Gov One Account after logging in
 
-  @test
-  Scenario: User Housekeeping if failure of tests
-    Given the user has access to their first-time ID code
-    Given the user visit plan your future
-    Then delete account housekeeping
+
+
   

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -1,7 +1,7 @@
 Feature: Home
 
   @test
-  Scenario: Full E2E registration GOV One then completed PYF then delete account
+  Scenario: Full E2E registration Gov One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
     Then they create an account with Gov One Login
@@ -29,3 +29,10 @@ Feature: Home
     Then the user Logs Out of the service
     Then the user logs into their account who has completed account setup
     Then the user deletes their Gov One Account after logging in
+
+  @test
+  Scenario: User Housekeeping if failure of tests
+    Given the user has access to their first-time ID code
+    Given the user visit plan your future
+    Then delete account housekeeping
+  

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -1,13 +1,13 @@
 Feature: Home
 
-  @test
+ @test
   Scenario: User Housekeeping if failure of tests
     Given the user has access to their first-time ID code
     Given the user visit plan your future
     Then delete account housekeeping
     
 
-  @test
+ @test
   Scenario: Full E2E registration Gov One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
@@ -16,7 +16,7 @@ Feature: Home
     Then the user deletes their Gov One Account
 
 
-  @test
+ @test
   Scenario: User registration to Gov One, then logs out, then logs back into complete registration then deletes account
     Given the user has access to their first-time ID code
     Given the user visit plan your future
@@ -27,7 +27,7 @@ Feature: Home
     Then the user deletes their Gov One Account after logging in
 
 
-  @test
+ @test
   Scenario: User registration to Gov One, then completes PYF then logs out, then logs back into PYF then deletes account
     Given the user has access to their first-time ID code
     Given the user visit plan your future
@@ -37,6 +37,15 @@ Feature: Home
     Then the user logs into their account who has completed account setup
     Then the user deletes their Gov One Account after logging in
 
+
+ @test 
+  Scenario: User registration to Gov One, then completes PYF then logs out, then tries to re-register with Gov One
+    Given the user has access to their first-time ID code
+    Given the user visit plan your future
+    Then they create an account with Gov One Login
+    Then the user completes the account setup with first-time ID code
+    Then the user Logs Out of the service
+    Then they try to re-create an existing account with Gov One Login
 
 
   

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -1,9 +1,31 @@
 Feature: Home
 
   @test
-  Scenario: Home: user can register
+  Scenario: Full E2E registration GOV One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
     Then they create an account with Gov One Login
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account
+
+
+  @test
+  Scenario: User registration to Gov One, then logs out, then logs back into complete registration then deletes account
+    Given the user has access to their first-time ID code
+    Given the user visit plan your future
+    Then they create an account with Gov One Login
+    Then the user Logs Out of the service
+    Then the user logs into their account who has not completed account setup
+    Then the user completes the account setup with first-time ID code
+    Then the user deletes their Gov One Account after logging in
+
+
+  @test
+  Scenario: User registration to Gov One, then completes PYF then logs out, then logs back into PYF then deletes account
+    Given the user has access to their first-time ID code
+    Given the user visit plan your future
+    Then they create an account with Gov One Login
+    Then the user completes the account setup with first-time ID code
+    Then the user Logs Out of the service
+    Then the user logs into their account who has completed account setup
+    Then the user deletes their Gov One Account after logging in

--- a/E2E_Tests/test/helpers/mailClient.js
+++ b/E2E_Tests/test/helpers/mailClient.js
@@ -55,7 +55,7 @@ async function returnSecurityCode(number) {
   startCount = number
 
   while (currentCount <= startCount) {
-    await sleep(2000)
+    await sleep(5000)
     currentCount = await authorize().then(countMessages).catch(console.error)
     console.log('in while loop current count ' + currentCount)
     console.log('in while loop start count ' + startCount)
@@ -147,7 +147,7 @@ async function listMessages(auth) {
   const res = await gmail.users.messages.list({
     userId: 'me',
   })
-  console.log('completed call')
+  console.log('completed listMessages call')
   const messages = res.data.messages
   if (!messages || messages.length === 0) {
     console.log('No messages found.')
@@ -163,7 +163,7 @@ async function countMessages(auth) {
   const res = await gmail.users.messages.list({
     userId: 'me',
   })
-  console.log('completed call')
+  console.log('completed countMessages call')
   const messages = res.data.messages
   if (!messages || messages.length === 0) {
     console.log('No messages found.')
@@ -182,7 +182,7 @@ async function getMessage(auth) {
     userId: 'me',
     id: id,
   })
-  console.log('completed call')
+  console.log('completed getMessages call')
   const messages = res.data.snippet
   const messageNumber = await extractSixDigitNumber(messages)
   console.log('email message number ' + messageNumber)
@@ -200,7 +200,7 @@ async function deleteLatestMessage(auth) {
     userId: 'me',
     id: id,
   })
-  console.log('completed call')
+  console.log('completed deleteLatestMessage call')
   console.log('email deleted ' + id)
 }
 

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -227,6 +227,15 @@ Then('delete account housekeeping', async function () {
   govOneEnterPassword = new GovOneEnterPassword(pageFixture.page)
   dashboardPage = new DashboardPage(pageFixture.page);
   navigationPage = new NavigationPage(pageFixture.page);
+  settingsPage = new SettingsPage(pageFixture.page);
+  govOneCheckEmail = new GovOneCheckEmail(pageFixture.page);
+  govOneChangedOTP = new GovOneChangedOTP(pageFixture.page);
+  govOneSecurityDetails = new GovOneSecurityDetails(pageFixture.page);
+  govOneSelectOTPMethod = new GovOneSelectOTPMethod(pageFixture.page);
+  govOneEnterOTPSecurityCode = new GovOneEnterOTPSecurityCode(pageFixture.page);
+  govOneCreatedAccount = new GovOneCreatedAccount(pageFixture.page);
+  completeAccountPage = new CompleteAccountPage(pageFixture.page);
+
   await homePage.clickStart();
   await govOneLogin.signInButton.click();
   console.log('user loging into account')
@@ -241,10 +250,6 @@ Then('delete account housekeeping', async function () {
     var testVal1 = await navigationPage.pageHeader.innerText();
     console.log(testVal1);
     if ((testVal1 == 'Finish creating your GOV.UK One Login')) {
-
-      govOneSelectOTPMethod = new GovOneSelectOTPMethod(pageFixture.page);
-      govOneEnterOTPSecurityCode = new GovOneEnterOTPSecurityCode(pageFixture.page);
-      govOneCreatedAccount = new GovOneCreatedAccount(pageFixture.page);
       const count = await returnCurrentCount();
       await govOneSelectOTPMethod.submitAuthAppOption();
       await govOneEnterOTPSecurityCode.iCannotSelectQRDropdown.click();
@@ -256,60 +261,59 @@ Then('delete account housekeeping', async function () {
       await govOneEnterOTPSecurityCode.submitCode(otpAuth);
       await govOneCreatedAccount.shouldFindTitle();
       await govOneCreatedAccount.continue.click();
+      await govOneSecurityDetails.gotoDeleteAccount();
+      await govOneSecurityDetails.submitPassword(password);
+      await govOneSecurityDetails.confirmAreYouSure();
+      console.log('govOne Account Deleted');
     }
-    // check to see if account is fully registered
-    var testVal2 = await navigationPage.pageHeader.innerText();
-    console.log(testVal2);
-    if ((testVal2 == 'Complete your account setup securely')) {
-      console.log('continuing to setup account');
-      // if not completed registration complete registration
-      completeAccountPage = new CompleteAccountPage(pageFixture.page);
-      await completeAccountPage.shouldFindTitle();
-      const firstTimeIdCode = await getFirstTimeIdCode();
-      await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
-      const dob = getDobArray
-      await completeAccountPage.submitDay(getDobArray[0]);
-      await completeAccountPage.submitMonth(getDobArray[1]);
-      await completeAccountPage.submitYear(getDobArray[2]);
-    }
-    console.log('deleteing account');
-    await dashboardPage.shouldFindTitle();
-    const count = await returnCurrentCount();
-    navigationPage = new NavigationPage(pageFixture.page);
-    settingsPage = new SettingsPage(pageFixture.page);
-    govOneEnterOTPSecurityCode = new GovOneEnterOTPSecurityCode(pageFixture.page);
-    govOneCheckEmail = new GovOneCheckEmail(pageFixture.page);
-    govOneSelectOTPMethod = new GovOneSelectOTPMethod(pageFixture.page);
-    govOneChangedOTP = new GovOneChangedOTP(pageFixture.page);
-    govOneSecurityDetails = new GovOneSecurityDetails(pageFixture.page);
-    
-    await navigationPage.settingsLink.click();
-    await settingsPage.shouldFindTitle();
-    await settingsPage.govOneLink.click();
-    console.log('govOnelinkClicked');
+    else {
+        // check to see if account is fully registered
+        var testVal2 = await navigationPage.pageHeader.innerText();
+        console.log(testVal2);
+        if ((testVal2 == 'Complete your account setup securely')) {
+          console.log('continuing to setup account');
+          // if not completed registration complete registration
+          await completeAccountPage.shouldFindTitle();
+          const firstTimeIdCode = await getFirstTimeIdCode();
+          await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
+          const dob = getDobArray
+          await completeAccountPage.submitDay(getDobArray[0]);
+          await completeAccountPage.submitMonth(getDobArray[1]);
+          await completeAccountPage.submitYear(getDobArray[2]);
+          }
+        console.log('deleteing account');
+        await dashboardPage.shouldFindTitle();
+        const count = await returnCurrentCount();
 
-    await govOneEnterOTPSecurityCode.gotoResetOTP();
-    console.log('should have redirected to check email');
-    const securityCode = await returnSecurityCode(count);
-    console.log(securityCode);
-    await govOneCheckEmail.submitCode(securityCode);
-    await govOneSelectOTPMethod.submitAuthAppOption();
-    await govOneEnterOTPSecurityCode.iCannotSelectQRDropdown.click();
-    const secret = await govOneEnterOTPSecurityCode.secretKey.innerText();
-    console.log('secret Key ...'+ secret.slice(-3));
-    var secretValue= secret.slice(12);
-    console.log('secret Key Trim ...'+secretValue.slice(-3));
-    const otpAuth = await getMyOTP(secretValue);
-    await govOneEnterOTPSecurityCode.submitCode(otpAuth);
-    await govOneChangedOTP.continue.click();
-    
-    await govOneSecurityDetails.shouldFindTitle();
-    await govOneSecurityDetails.gotoDeleteAccount();
-    await govOneSecurityDetails.submitPassword(password);
-    await govOneSecurityDetails.confirmAreYouSure();
-    console.log('govOne Account Deleted');
 
-  } 
+        await navigationPage.settingsLink.click();
+        await settingsPage.shouldFindTitle();
+        await settingsPage.govOneLink.click();
+        console.log('govOnelinkClicked');
+
+        await govOneEnterOTPSecurityCode.gotoResetOTP();
+        console.log('should have redirected to check email');
+        const securityCode = await returnSecurityCode(count);
+        console.log(securityCode);
+        await govOneCheckEmail.submitCode(securityCode);
+        await govOneSelectOTPMethod.submitAuthAppOption();
+        await govOneEnterOTPSecurityCode.iCannotSelectQRDropdown.click();
+        const secret = await govOneEnterOTPSecurityCode.secretKey.innerText();
+        console.log('secret Key ...'+ secret.slice(-3));
+        var secretValue= secret.slice(12);
+        console.log('secret Key Trim ...'+secretValue.slice(-3));
+        const otpAuth = await getMyOTP(secretValue);
+        await govOneEnterOTPSecurityCode.submitCode(otpAuth);
+        await govOneChangedOTP.continue.click();
+
+        await govOneSecurityDetails.shouldFindTitle();
+        await govOneSecurityDetails.gotoDeleteAccount();
+        await govOneSecurityDetails.submitPassword(password);
+        await govOneSecurityDetails.confirmAreYouSure();
+        console.log('govOne Account Deleted');
+
+      } 
+  }
   else{
   // no need to delete account if not in if statement.
   console.log('no account was to be deleted');

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -19,6 +19,7 @@ import SettingsPage from '../../pageObjects/settingsPage'
 import GovOneChangedOTP from '../../pageObjects/govOne/govOneChangedOTP'
 import GovOneSecurityDetails from '../../pageObjects/govOne/govOneYourDetailsSecuityPage'
 import { getFirstTimeIdCode, getDobArray } from '../helpers/firstTimeIdCode'
+import exp from 'constants'
 
 setDefaultTimeout(20000)
 let page: Page;
@@ -100,6 +101,24 @@ Then('they create an account with Gov One Login', async function () {
   await govOneEnterOTPSecurityCode.submitCode(otpAuth);
   await govOneCreatedAccount.shouldFindTitle();
   await govOneCreatedAccount.continue.click();
+})
+
+Then('they try to re-create an existing account with Gov One Login', async function () {
+  govOneLogin = new GovOneLogin(pageFixture.page);
+  govOneEnterEmail = new GovOneEnterEmail(pageFixture.page);
+  govOneCreatedAccount = new GovOneCreatedAccount(pageFixture.page);
+  navigationPage = new NavigationPage(pageFixture.page);
+  govOneEnterPassword = new GovOneEnterPassword(pageFixture.page)
+  dashboardPage = new DashboardPage(pageFixture.page);
+  await homePage.clickStart();
+  const count = await returnCurrentCount();
+  console.log('govOneLogin');
+  await govOneLogin.createLogin.click();
+  console.log('creating loging')
+  await govOneEnterEmail.submitEmail(email);
+  await expect(navigationPage.pageHeader).toHaveText('You have a GOV.UK One Login');
+  await govOneEnterPassword.submitPassword(password);
+  await dashboardPage.shouldFindTitle();
 })
 
 Then('the user logs into their account who has completed account setup', async function () {
@@ -213,12 +232,31 @@ Then('delete account housekeeping', async function () {
   console.log('user loging into account')
   await govOneEnterEmail.submitEmail(email);
   // check header here to see if account exists..
-  var testVal1 = await navigationPage.pageHeader.innerText();
-  console.log(testVal1);
-  if ((testVal1 == 'Enter your password')) {
+  var testVal0 = await navigationPage.pageHeader.innerText();
+  console.log(testVal0);
+  if ((testVal0 == 'Enter your password')) {
     console.log('continuing to log into account');
     await govOneEnterPassword.submitPassword(password);
+    // check header here to see Gov One Acc and has been completed
+    var testVal1 = await navigationPage.pageHeader.innerText();
+    console.log(testVal1);
+    if ((testVal1 == 'Finish creating your GOV.UK One Login')) {
 
+      govOneSelectOTPMethod = new GovOneSelectOTPMethod(pageFixture.page);
+      govOneEnterOTPSecurityCode = new GovOneEnterOTPSecurityCode(pageFixture.page);
+      govOneCreatedAccount = new GovOneCreatedAccount(pageFixture.page);
+      const count = await returnCurrentCount();
+      await govOneSelectOTPMethod.submitAuthAppOption();
+      await govOneEnterOTPSecurityCode.iCannotSelectQRDropdown.click();
+      const secret = await govOneEnterOTPSecurityCode.secretKey.innerText();
+      console.log('secret Key ...'+ secret.slice(-3));
+      var secretValue= secret.slice(12);
+      console.log('secret Key Trim ...'+secretValue.slice(-3));
+      const otpAuth = await getMyOTP(secretValue);
+      await govOneEnterOTPSecurityCode.submitCode(otpAuth);
+      await govOneCreatedAccount.shouldFindTitle();
+      await govOneCreatedAccount.continue.click();
+    }
     // check to see if account is fully registered
     var testVal2 = await navigationPage.pageHeader.innerText();
     console.log(testVal2);

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -200,23 +200,30 @@ Then('the user deletes their Gov One Account after logging in', async function (
 
 })
 
-
+// the following Code is if error in tests and account is still existing this will delete account for next run; controlled in feature file. 
 Then('delete account housekeeping', async function () {
 
   govOneLogin = new GovOneLogin(pageFixture.page);
   govOneEnterEmail = new GovOneEnterEmail(pageFixture.page);
   govOneEnterPassword = new GovOneEnterPassword(pageFixture.page)
   dashboardPage = new DashboardPage(pageFixture.page);
+  navigationPage = new NavigationPage(pageFixture.page);
   await homePage.clickStart();
   await govOneLogin.signInButton.click();
   console.log('user loging into account')
   await govOneEnterEmail.submitEmail(email);
   // check header here to see if account exists..
-  if ((await page.$('#elem-id')) !== null) {
+  var testVal1 = await navigationPage.pageHeader.innerText();
+  console.log(testVal1);
+  if ((testVal1 == 'Enter your password')) {
+    console.log('continuing to log into account');
     await govOneEnterPassword.submitPassword(password);
 
     // check to see if account is fully registered
-    if ((await page.$('#elem-id')) !== null) {
+    var testVal2 = await navigationPage.pageHeader.innerText();
+    console.log(testVal2);
+    if ((testVal2 == 'Complete your account setup securely')) {
+      console.log('continuing to setup account');
       // if not completed registration complete registration
       completeAccountPage = new CompleteAccountPage(pageFixture.page);
       await completeAccountPage.shouldFindTitle();
@@ -227,6 +234,7 @@ Then('delete account housekeeping', async function () {
       await completeAccountPage.submitMonth(getDobArray[1]);
       await completeAccountPage.submitYear(getDobArray[2]);
     }
+    console.log('deleteing account');
     await dashboardPage.shouldFindTitle();
     const count = await returnCurrentCount();
     navigationPage = new NavigationPage(pageFixture.page);
@@ -264,6 +272,9 @@ Then('delete account housekeeping', async function () {
     console.log('govOne Account Deleted');
 
   } 
+  else{
   // no need to delete account if not in if statement.
-  console.log('account was deleted or not created')
+  console.log('no account was to be deleted');
+  }
+
 })

--- a/E2E_Tests/test/steps/psfrLoginSteps.ts
+++ b/E2E_Tests/test/steps/psfrLoginSteps.ts
@@ -1,4 +1,4 @@
-import { Given, setDefaultTimeout } from '@cucumber/cucumber'
+import { Given, Then, setDefaultTimeout } from '@cucumber/cucumber'
 import { pageFixture } from '../../hooks/pageFixtures'
 import CommonPage from '../../pageObjects/psfr/commonPage'
 import fs from 'fs'
@@ -22,3 +22,16 @@ Given('the user has access to their first-time ID code', async function () {
 
 })
 
+
+Then('the user requests for their first-time ID code', async function () {
+  commonPage = new CommonPage(pageFixture.page)
+  const url = process.env.PSFRURL || ''
+  await pageFixture.page.goto(`${url}/prisoner-overview/?prisonerNumber=A8731DY`)
+  await pageFixture.page.getByText("Generate First-time ID code").click()
+  const otpCode = await (await pageFixture.page.waitForSelector('#otp-code')).innerText()
+  fs.writeFile('./otp.txt', otpCode, (err) => {
+    if (err) throw err;
+    console.log(`OTP ${otpCode} written to otp.txt`);
+  });
+
+})


### PR DESCRIPTION
added all login scenarios through gov one login to PYF account
deletes accounts at ends of all tests
added housekeeping test should a test fail this will still continue to delete account

added longer time out on email client service to ensure no overlap with email receipt when running multiple tests.