### PR TITLE
Revert "Make preprod deploy depend on e2e test (#225)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ workflows:
       - request-preprod-approval:
           type: approval
           requires:
-            - e2e_test
+            - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"


### PR DESCRIPTION
This reverts commit 5c623691bed7cbc92114431afe658fe273608714.