### PR TITLE
PLT-487 Validate licence id belongs to user

### DIFF
--- a/integration_tests/e2e/licenceConditions.cy.ts
+++ b/integration_tests/e2e/licenceConditions.cy.ts
@@ -1,6 +1,7 @@
 import StartPage from '../pages/start'
 import LicencePage from '../pages/licence'
 import Page from '../pages/page'
+import NotFoundPage from '../pages/notFoundPage'
 
 context('Licence conditions', () => {
   beforeEach(() => {
@@ -195,5 +196,13 @@ context('Licence conditions', () => {
     // and should be able to go back
     cy.get('#back-licence-details-link').click()
     Page.verifyOnPage(LicencePage)
+  })
+
+  it('Should see not found if ask for details of licence that is not assigned to user', () => {
+    cy.task('stubGetLicenceConditions')
+    cy.signIn()
+
+    cy.visit({ url: 'licence-conditions/123/condition/1', failOnStatusCode: false })
+    Page.verifyOnPage(NotFoundPage)
   })
 })

--- a/integration_tests/pages/notFoundPage.ts
+++ b/integration_tests/pages/notFoundPage.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class NotFoundPage extends Page {
+  constructor() {
+    super('Page not found')
+  }
+}

--- a/server/routes/licenceConditions/licenceConditionsController.ts
+++ b/server/routes/licenceConditions/licenceConditionsController.ts
@@ -90,6 +90,11 @@ export default class LicenceConditionsController {
         verificationData.nomsId,
         sessionId,
       )
+
+      if (licence.licenceId !== licenceId) {
+        return res.status(404).render('pages/notFound', { user: req.user })
+      }
+
       const condition = licence.otherLicenseConditions.find(x => x.id === conditionId)
       const image = await this.licenceConditionsService.getLicenceConditionsImage(
         verificationData.nomsId,

--- a/server/views/pages/notFound.njk
+++ b/server/views/pages/notFound.njk
@@ -2,6 +2,10 @@
 {% set pageTitle = "Not Found" + titleHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
+{% block beforeContent %}
+  {% include "../partials/limited-subnavigation.njk" %}
+{% endblock %}
+
 {% block content %}
   <h1 class="govuk-heading-xl govuk-!-margin-top-4" data-qa="notfound-page-title">{{ t('not-found-h1') }}</h1>
   <p>{{ t('not-found-p1') }}</p>


### PR DESCRIPTION
On licence conditions detail page. Currently could be used to leak LC images from other licences