### PR TITLE
Increase session timeout & reduce api cache expiry 

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,6 +28,7 @@ generic-service:
     CONTENTFUL_REFRESH_SECONDS: 10
     RATE_LIMIT_PER_MINUTE: 50
     FEATURE_FLAG_ENABLED: "true"
+    PSFR_API_CACHE_EXPIRY_SECONDS: 10
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,7 +23,7 @@ generic-service:
     POP_API_URL: "https://person-on-probation-user-api-dev.hmpps.service.justice.gov.uk/person-on-probation-user"
     GOVUK_ONE_LOGIN_VTR: "LOW"
     GOVUK_ONE_LOGIN_JWKS_URL: "https://oidc.integration.account.gov.uk/.well-known/jwks.json"
-    WEB_SESSION_INACTIVITY_IN_MINUTES: 5
+    WEB_SESSION_INACTIVITY_IN_MINUTES: 20
     CONTENTFUL_SHOW_PREVIEW: "true"
     CONTENTFUL_REFRESH_SECONDS: 10
     RATE_LIMIT_PER_MINUTE: 50

--- a/server/config.ts
+++ b/server/config.ts
@@ -101,6 +101,7 @@ export default {
       },
       agent: new AgentConfig(Number(get('PERSON_ON_PROBATION_USER_API_TIMEOUT_RESPONSE', 20000))),
       enabled: get('PSFR_API_ENABLED', 'true') === 'true',
+      cacheExpirySeconds: Number(get('PSFR_API_CACHE_EXPIRY_SECONDS', 20 * 60)),
     },
     zendesk: {
       url: get('ZENDESK_API_URL', 'http://localhost:8101', requiredInProduction),

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -46,7 +46,11 @@ export default class UserService {
     const fetchedPersonalDetails = await this.resettlementPassportClient.getByNomsId(nomsId, sessionId)
     if (fetchedPersonalDetails && config.redis.enabled) {
       // store to cache
-      await this.tokenStore.setToken(key, JSON.stringify(fetchedPersonalDetails), config.session.expiryMinutes * 60)
+      await this.tokenStore.setToken(
+        key,
+        JSON.stringify(fetchedPersonalDetails),
+        config.apis.resettlementPassportApi.cacheExpirySeconds,
+      )
     }
     return fetchedPersonalDetails
   }
@@ -69,7 +73,11 @@ export default class UserService {
     const fetchedUser = await this.personOnProbationUserApiClient.getUserByUrn(urn, sessionId)
     if (fetchedUser) {
       // store to cache
-      await this.tokenStore.setToken(key, JSON.stringify(fetchedUser), config.session.expiryMinutes * 60)
+      await this.tokenStore.setToken(
+        key,
+        JSON.stringify(fetchedUser),
+        config.apis.resettlementPassportApi.cacheExpirySeconds,
+      )
     }
 
     return Promise.resolve(fetchedUser)


### PR DESCRIPTION
On dev. Add new env var for api cache instead of reusing session var
