### PR TITLE
E2e test plt 493

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,9 @@ jobs:
             export BASEURL=${DEV_BASEURL}
             export PSFRURL=${DEV_PSFRURL}
             export USEREMAIL=${E2E_USEREMAIL}
+            export FIRSTNAME=${E2E_FIRSTNAME}
+            export LASTNAME=${E2E_LASTNAME}
+            export PRISONERNUMBER=${E2E_PRISONERNUMBER}
             export USERPASSWORD=${E2E_USERPASSWORD}
             export GMAIL_CLIENT_ID=${E2E_GMAIL_CLIENT_ID}
             export GMAIL_CLIENT_SECRET=${E2E_GMAIL_CLIENT_SECRET}

--- a/E2E_Tests/pageObjects/alternateCompleteAccountPage.ts
+++ b/E2E_Tests/pageObjects/alternateCompleteAccountPage.ts
@@ -9,7 +9,6 @@ export default class AlternateCompleteAccountPage {
   readonly enterMonth: Locator;
   readonly enterYear: Locator;
   readonly continue: Locator;
-  readonly selectAlternateLogin: Locator;
   readonly enterFirstName: Locator;
   readonly enterLastName: Locator;
   readonly enterPrisonerNumber: Locator;

--- a/E2E_Tests/pageObjects/alternateCompleteAccountPage.ts
+++ b/E2E_Tests/pageObjects/alternateCompleteAccountPage.ts
@@ -1,0 +1,52 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+export default class AlternateCompleteAccountPage {
+  private page: Page
+
+  readonly pageHeader: Locator
+  readonly enterFirstTimeIdCode: Locator;
+  readonly enterDay: Locator;
+  readonly enterMonth: Locator;
+  readonly enterYear: Locator;
+  readonly continue: Locator;
+  readonly selectAlternateLogin: Locator;
+  readonly enterFirstName: Locator;
+  readonly enterLastName: Locator;
+  readonly enterPrisonerNumber: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.pageHeader = page.locator('h1', { hasText: 'Complete your account setup securely'});
+    this.enterFirstName = page.locator('#first-name');
+    this.enterLastName = page.locator('#last-name');
+    this.enterDay = page.locator('#dob-day');
+    this.enterMonth = page.locator('#dob-month');
+    this.enterYear = page.locator('#dob-year');
+    this.continue = page.locator('#submit');
+    this.enterPrisonerNumber = page.locator('#prisoner-number');
+  }
+
+
+  async shouldFindTitle() {
+    await expect(this.pageHeader).toBeVisible();
+  }
+  async submitFirstName(firstName: string) {
+    await this.enterFirstName.fill(firstName);
+  }
+  async submitLastName(lastName: string) {
+    await this.enterLastName.fill(lastName);
+  }
+  async submitPrisonerNumber(prisonerNumber: string) {
+    await this.enterPrisonerNumber.fill(prisonerNumber);
+  }
+  async submitDay(day: string) {
+    await this.enterDay.fill(day);
+  }
+  async submitMonth(month: string) {
+    await this.enterMonth.fill(month);
+  }
+  async submitYear(year: string) {
+    await this.enterYear.fill(year);
+    await this.continue.click();
+  }
+}

--- a/E2E_Tests/pageObjects/completeAccountPage.ts
+++ b/E2E_Tests/pageObjects/completeAccountPage.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 
-export default class CompleteAccourtPage {
+export default class CompleteAccountPage {
   private page: Page
 
   readonly pageHeader: Locator

--- a/E2E_Tests/pageObjects/completeAccountPage.ts
+++ b/E2E_Tests/pageObjects/completeAccountPage.ts
@@ -10,24 +10,23 @@ export default class CompleteAccourtPage {
   readonly enterYear: Locator;
   readonly continue: Locator;
   readonly warning: Locator;
+  readonly noOneTimePassword: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.pageHeader = page.locator('h1', { hasText: 'Complete your account setup securely'});
+    this.pageHeader = page.locator('h1', { hasText: 'Complete your account setup securely' });
     this.enterFirstTimeIdCode = page.locator('//*[@id="otp"]');
     this.enterDay = page.locator('//*[@id="dobDay"]');
     this.enterMonth = page.locator('//*[@id="dobMonth"]');
     this.enterYear = page.locator('//*[@id="dobYear"]');
     this.continue = page.locator('//*[@id="main-content"]/div/div/form/button');
     this.warning = page.locator('//*[@id="main-content"]/div[1]/div/div/ul/li/a');
-
+    this.noOneTimePassword = page.locator('#main-content > div:nth-child(2) > div > a')
   }
-
 
   async shouldFindTitle() {
     await expect(this.pageHeader).toBeVisible();
   }
-
 
   async submitFirstTimeIdCode(id: string) {
     await this.enterFirstTimeIdCode.fill(id);
@@ -41,5 +40,8 @@ export default class CompleteAccourtPage {
   async submitYear(year: string) {
     await this.enterYear.fill(year);
     await this.continue.click();
+  }
+  async clickNoOneTimePasswordLink() {
+    await this.noOneTimePassword.click();
   }
 }

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -1,6 +1,6 @@
 Feature: Home
 
-@test
+#@test
   Scenario Outline: 1-3) User Housekeeping if failure of tests
     Given the user has access to their first-time ID code
     Given the user visit plan your future
@@ -12,49 +12,56 @@ Feature: Home
     | "+131@gmail.com" |
     | "+132@gmail.com" |
 
-@test
+#@test
   Scenario: 4) Full E2E registration Gov One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
-    Then they create an account with Gov One Login email "+130@gmail.com"
+    Then they create an account with Gov One Login email "+800@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account
 
-@test
+#@test
   Scenario: 5) User registration to Gov One, then completes PYF then logs out, then logs back into PYF then deletes account
     Given the user has access to their first-time ID code
     Given the user visit plan your future
-    Then they create an account with Gov One Login email "+131@gmail.com"
+    Then they create an account with Gov One Login email "+801@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user Logs Out of the service
-    Then the user logs into their account who has completed account setup email "+131@gmail.com"
+    Then the user logs into their account who has completed account setup email "+801@gmail.com"
     Then the user deletes their Gov One Account after logging in
 
-@test
+#@test
   Scenario: 6) Full E2E registration Gov One then completed PYF then delete account tries to register with same OTP NOMIS ID, requests new OTP to complete registration
     Given the user has access to their first-time ID code
     When the user visit plan your future
-    Then they create an account with Gov One Login email "+132@gmail.com"
+    Then they create an account with Gov One Login email "+802@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account
     Then the user revisits plan your future
     Then the user will be still logged into current session so Logs Out of the service
-    Then they create an account with Gov One Login email "+132@gmail.com"
+    Then they create an account with Gov One Login email "+802@gmail.com"
     Then the user completes the account setup with expired first-time ID code
     Then the user Logs Out of the service
     Then the user requests for their first-time ID code
     Then the user revisits plan your future
-    Then the user logs into their account who has not completed account setup email "+132@gmail.com"
+    Then the user logs into their account who has not completed account setup email "+802@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account after logging in
 
-@test
+#@test
   Scenario: 7) User uploads Licence Conditions file in PSFR and views in PYF
     Given the user uploads a licence conditions document for a prisoner
     When the user visit plan your future
     Then the user logs into their account who has completed account setup email "+5@gmail.com"
     Then the user views their Licence Conditions PDF
-    Then the user Logs Out of the service    
+    Then the user Logs Out of the service  
+
+Scenario: 8) Full E2E registration Gov One then completed PYF then delete account
+    Given the user has access to their first-time ID code
+    When the user visit plan your future
+    Then they create an account with Gov One Login email "+803@gmail.com"
+    Then the user completes the account setup without first-time ID code
+    Then the user deletes their Gov One Account  
 
 @ignore
   Scenario: 0) User logs into PYF in pre-existing account (only used for troubleshooting)

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -1,6 +1,5 @@
 Feature: Home
 
-#@test
   Scenario Outline: 1-3) User Housekeeping if failure of tests
     Given the user has access to their first-time ID code
     Given the user visit plan your future
@@ -12,7 +11,6 @@ Feature: Home
     | "+131@gmail.com" |
     | "+132@gmail.com" |
 
-#@test
   Scenario: 4) Full E2E registration Gov One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
@@ -20,7 +18,6 @@ Feature: Home
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account
 
-#@test
   Scenario: 5) User registration to Gov One, then completes PYF then logs out, then logs back into PYF then deletes account
     Given the user has access to their first-time ID code
     Given the user visit plan your future
@@ -30,7 +27,6 @@ Feature: Home
     Then the user logs into their account who has completed account setup email "+801@gmail.com"
     Then the user deletes their Gov One Account after logging in
 
-#@test
   Scenario: 6) Full E2E registration Gov One then completed PYF then delete account tries to register with same OTP NOMIS ID, requests new OTP to complete registration
     Given the user has access to their first-time ID code
     When the user visit plan your future
@@ -48,7 +44,7 @@ Feature: Home
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account after logging in
 
-#@test
+
   Scenario: 7) User uploads Licence Conditions file in PSFR and views in PYF
     Given the user uploads a licence conditions document for a prisoner
     When the user visit plan your future
@@ -56,11 +52,12 @@ Feature: Home
     Then the user views their Licence Conditions PDF
     Then the user Logs Out of the service  
 
-Scenario: 8) Full E2E registration Gov One then completed PYF then delete account
+@test
+Scenario: 8) Full E2E registration Gov One without one time password then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
     Then they create an account with Gov One Login email "+803@gmail.com"
-    Then the user completes the account setup without first-time ID code
+    Then the user completes the account setup without one time password
     Then the user deletes their Gov One Account  
 
 @ignore
@@ -68,10 +65,3 @@ Scenario: 8) Full E2E registration Gov One then completed PYF then delete accoun
     Given the user visit plan your future
     Then the user logs into their account who has completed account setup email "+1@gmail.com"
     Then the user Logs Out of the service
-
-
-
-
-
-
-  

--- a/E2E_Tests/test/features/Home.feature
+++ b/E2E_Tests/test/features/Home.feature
@@ -11,40 +11,43 @@ Feature: Home
     | "+131@gmail.com" |
     | "+132@gmail.com" |
 
+@test
   Scenario: 4) Full E2E registration Gov One then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
-    Then they create an account with Gov One Login email "+800@gmail.com"
+    Then they create an account with Gov One Login email "+130@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account
 
+@test
   Scenario: 5) User registration to Gov One, then completes PYF then logs out, then logs back into PYF then deletes account
     Given the user has access to their first-time ID code
     Given the user visit plan your future
-    Then they create an account with Gov One Login email "+801@gmail.com"
+    Then they create an account with Gov One Login email "+131@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user Logs Out of the service
-    Then the user logs into their account who has completed account setup email "+801@gmail.com"
+    Then the user logs into their account who has completed account setup email "+131@gmail.com"
     Then the user deletes their Gov One Account after logging in
 
+@test
   Scenario: 6) Full E2E registration Gov One then completed PYF then delete account tries to register with same OTP NOMIS ID, requests new OTP to complete registration
     Given the user has access to their first-time ID code
     When the user visit plan your future
-    Then they create an account with Gov One Login email "+802@gmail.com"
+    Then they create an account with Gov One Login email "+132@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account
     Then the user revisits plan your future
     Then the user will be still logged into current session so Logs Out of the service
-    Then they create an account with Gov One Login email "+802@gmail.com"
+    Then they create an account with Gov One Login email "+132@gmail.com"
     Then the user completes the account setup with expired first-time ID code
     Then the user Logs Out of the service
     Then the user requests for their first-time ID code
     Then the user revisits plan your future
-    Then the user logs into their account who has not completed account setup email "+802@gmail.com"
+    Then the user logs into their account who has not completed account setup email "+132@gmail.com"
     Then the user completes the account setup with first-time ID code
     Then the user deletes their Gov One Account after logging in
 
-
+@test
   Scenario: 7) User uploads Licence Conditions file in PSFR and views in PYF
     Given the user uploads a licence conditions document for a prisoner
     When the user visit plan your future
@@ -56,7 +59,7 @@ Feature: Home
 Scenario: 8) Full E2E registration Gov One without one time password then completed PYF then delete account
     Given the user has access to their first-time ID code
     When the user visit plan your future
-    Then they create an account with Gov One Login email "+803@gmail.com"
+    Then they create an account with Gov One Login email "+133@gmail.com"
     Then the user completes the account setup without one time password
     Then the user deletes their Gov One Account  
 

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -55,6 +55,9 @@ let documentsPage: DocumentsPage;
 
 const email = process.env.USEREMAIL
 const password = process.env.USERPASSWORD
+const firstName = process.env.FIRSTNAME
+const lastName = process.env.LASTNAME
+const prisonerNumber = process.env.PRISONERNUMBER
 
 
 function sleep(ms: number | undefined) {
@@ -231,12 +234,16 @@ Then('the user completes the account setup with first-time ID code', async funct
 
 Then('the user completes the account setup without first-time ID code', async function () {
   alternateCompleteAccountPage = new AlternateCompleteAccountPage(pageFixture.page);
+  completeAccountPage = new CompleteAccountPage(pageFixture.page);
   dashboardPage = new DashboardPage(pageFixture.page);
   await sleep(500)
+  await completeAccountPage.clickNoOneTimePasswordLink();
   await alternateCompleteAccountPage.shouldFindTitle();
   // const firstTimeIdCode = await getFirstTimeIdCode();
   // await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
-  await alternateCompleteAccountPage.enterFirstName('John');
+  await alternateCompleteAccountPage.submitFirstName(firstName);
+  await alternateCompleteAccountPage.submitLastName(lastName);
+  await alternateCompleteAccountPage.submitPrisonerNumber(prisonerNumber);
   const dob = getDobArray
   await completeAccountPage.submitDay(getDobArray[0]);
   await completeAccountPage.submitMonth(getDobArray[1]);

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -232,7 +232,7 @@ Then('the user completes the account setup with first-time ID code', async funct
   await dashboardPage.shouldFindTitle();
 })
 
-Then('the user completes the account setup without first-time ID code', async function () {
+Then('the user completes the account setup without one time password', async function () {
   alternateCompleteAccountPage = new AlternateCompleteAccountPage(pageFixture.page);
   completeAccountPage = new CompleteAccountPage(pageFixture.page);
   dashboardPage = new DashboardPage(pageFixture.page);

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -13,6 +13,7 @@ import GovOneCreatedAccount from '../../pageObjects/govOne/govOneCreatedAccount'
 import GovOneCheckEmail from '../../pageObjects/govOne/govOneCheckEmail'
 import GovOneSelectOTPMethod from '../../pageObjects/govOne/govOneSelectOTPMethod'
 import CompleteAccountPage from '../../pageObjects/completeAccountPage'
+import AlternateCompleteAccountPage from '../../pageObjects/alternateCompleteAccountPage'
 import DashboardPage from '../../pageObjects/dashboardPage'
 import NavigationPage from '../../pageObjects/navigationPage'
 import SettingsPage from '../../pageObjects/settingsPage'
@@ -44,6 +45,7 @@ let govOneSecurityDetails: GovOneSecurityDetails;
 let govOneEnterEmail: GovOneEnterEmail;
 let govOneEnterPassword: GovOneEnterPassword;
 let completeAccountPage: CompleteAccountPage;
+let alternateCompleteAccountPage: AlternateCompleteAccountPage;
 
 //pyf pages
 let dashboardPage: DashboardPage;
@@ -219,6 +221,22 @@ Then('the user completes the account setup with first-time ID code', async funct
   await completeAccountPage.shouldFindTitle();
   const firstTimeIdCode = await getFirstTimeIdCode();
   await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
+  const dob = getDobArray
+  await completeAccountPage.submitDay(getDobArray[0]);
+  await completeAccountPage.submitMonth(getDobArray[1]);
+  await completeAccountPage.submitYear(getDobArray[2]);
+  await sleep(500)
+  await dashboardPage.shouldFindTitle();
+})
+
+Then('the user completes the account setup without first-time ID code', async function () {
+  alternateCompleteAccountPage = new AlternateCompleteAccountPage(pageFixture.page);
+  dashboardPage = new DashboardPage(pageFixture.page);
+  await sleep(500)
+  await alternateCompleteAccountPage.shouldFindTitle();
+  // const firstTimeIdCode = await getFirstTimeIdCode();
+  // await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
+  await alternateCompleteAccountPage.enterFirstName('John');
   const dob = getDobArray
   await completeAccountPage.submitDay(getDobArray[0]);
   await completeAccountPage.submitMonth(getDobArray[1]);

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -239,8 +239,8 @@ Then('the user completes the account setup without first-time ID code', async fu
   await sleep(500)
   await completeAccountPage.clickNoOneTimePasswordLink();
   await alternateCompleteAccountPage.shouldFindTitle();
-  // const firstTimeIdCode = await getFirstTimeIdCode();
-  // await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
+  const firstTimeIdCode = await getFirstTimeIdCode();
+  await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
   await alternateCompleteAccountPage.submitFirstName(firstName);
   await alternateCompleteAccountPage.submitLastName(lastName);
   await alternateCompleteAccountPage.submitPrisonerNumber(prisonerNumber);

--- a/E2E_Tests/test/steps/commonSteps.ts
+++ b/E2E_Tests/test/steps/commonSteps.ts
@@ -238,16 +238,13 @@ Then('the user completes the account setup without one time password', async fun
   dashboardPage = new DashboardPage(pageFixture.page);
   await sleep(500)
   await completeAccountPage.clickNoOneTimePasswordLink();
-  await alternateCompleteAccountPage.shouldFindTitle();
-  const firstTimeIdCode = await getFirstTimeIdCode();
-  await completeAccountPage.submitFirstTimeIdCode(firstTimeIdCode);
   await alternateCompleteAccountPage.submitFirstName(firstName);
   await alternateCompleteAccountPage.submitLastName(lastName);
   await alternateCompleteAccountPage.submitPrisonerNumber(prisonerNumber);
   const dob = getDobArray
-  await completeAccountPage.submitDay(getDobArray[0]);
-  await completeAccountPage.submitMonth(getDobArray[1]);
-  await completeAccountPage.submitYear(getDobArray[2]);
+  await alternateCompleteAccountPage.submitDay(getDobArray[0]);
+  await alternateCompleteAccountPage.submitMonth(getDobArray[1]);
+  await alternateCompleteAccountPage.submitYear(getDobArray[2]);
   await sleep(500)
   await dashboardPage.shouldFindTitle();
 })


### PR DESCRIPTION
Addition of full e2e Gov one registration without one time password scenario. 

To cater for the journey a user would follow registering a new Gov one account if they don't have a one time passcode

Work done: 
- added new page object class E2E_Tests/pageObjects/alternateCompleteAccountPage.ts
- extended E2E_Tests/pageObjects/completeAccountPage.ts
- extended .circleci/config.yml
- extended E2E_Tests/test/features/Home.feature
- extended E2E_Tests/test/steps/commonSteps.ts