### PR TITLE
RSP-2071: Fix JWT issue from openid-client 5.7.1

### DIFF
--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -67,6 +67,11 @@ async function init(): Promise<Client> {
         ui_locales: 'en',
       },
       usePKCE: false,
+      extras: {
+        clientAssertionPayload: {
+          aud: [...new Set([issuer.issuer, issuer.token_endpoint].filter(Boolean))],
+        },
+      },
     },
     verify,
   )


### PR DESCRIPTION
Upgrading from openid-client 5.7.0 to 5.7.1 was causing an error:

`Error info: OPError: invalid_client (Invalid signature in private_key_jwt)`

Fixed using the proposed workaround from the openid-client library itself:
https://github.com/panva/openid-client/commit/0b05217e7f283b75fd93c27c0f8c647f37501a33