### PR TITLE
RSP-2071: Updated OTP test file

### DIFF
--- a/pt_tests/helpers/otpAuth.js
+++ b/pt_tests/helpers/otpAuth.js
@@ -1,5 +1,3 @@
-import { crypto } from 'k6/experimental/webcrypto';
-
 export async function totp(key, secs = 30, digits = 6){
 	return hotp(unbase32(key), pack64bu(Date.now() / 1000 / secs), digits);
 }
@@ -32,11 +30,3 @@ function pack64bu(v){
 	d.setUint32(4, v);
 	return b;
 }
-
-
-async function test(){
-    const testOTP = await totp("HEWGKXC2TUG4SI32C3NPQMPIBRHGC43E");
-    console.log(testOTP);
-}
-
-test();


### PR DESCRIPTION
- Removed the random key which was testing the `totp` function
- Removed deprecated webcrypto import in favour of the new crypto object ([see here](https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/webcrypto/))