### PR TITLE
RSP-2083: Install hmpps-precommit-hooks 

### DIFF
--- a/.gitleaks/.gitleaksignore
+++ b/.gitleaks/.gitleaksignore
@@ -1,0 +1,1 @@
+# The Fingerprint of false positive alerts can be added here to be excluded from future scans.

--- a/.gitleaks/config.toml
+++ b/.gitleaks/config.toml
@@ -1,0 +1,3 @@
+title = "HMPPS Gitleaks configuration"
+[extend]
+path = "./node_modules/@ministryofjustice/hmpps-precommit-hooks/config.toml"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,5 @@
-#!/bin/sh
-NODE_ENV=dev && npm run build && npm run typecheck && npm run lint
+#!/bin/bash
+NODE_ENV=dev \
+npm run precommit:secrets \
+&& npm run precommit:lint \
+&& npm run precommit:verify

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.9.1",
         "@google-cloud/local-auth": "^3.0.1",
-        "@ministryofjustice/hmpps-precommit-hooks": "^0.0.2",
+        "@ministryofjustice/hmpps-precommit-hooks": "^0.0.1",
         "@playwright/test": "^1.52.0",
         "@types/bunyan": "^1.8.11",
         "@types/bunyan-format": "^0.2.9",
@@ -2820,9 +2820,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-precommit-hooks": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-precommit-hooks/-/hmpps-precommit-hooks-0.0.2.tgz",
-      "integrity": "sha512-zTt1VxIdzhrY3srT/cCosyW8bTc9+afnAgbL647WkTAtUXfDAHu8mqNFf/2Ek5SulWojhx/oM7luJ2+htP9NFA==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-precommit-hooks/-/hmpps-precommit-hooks-0.0.1.tgz",
+      "integrity": "sha512-cwYwlLaEAJwzt/CNm/0VssWw/zDJbN4G1Qc/HSdITFY40zynrsTdzlFKy5TUDh8yUx9OLwiplM2HSJveb0PZTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.9.1",
         "@google-cloud/local-auth": "^3.0.1",
+        "@ministryofjustice/hmpps-precommit-hooks": "^0.0.2",
         "@playwright/test": "^1.52.0",
         "@types/bunyan": "^1.8.11",
         "@types/bunyan-format": "^0.2.9",
@@ -94,7 +95,6 @@
         "eslint-plugin-prettier": "^5.4.0",
         "globals": "^15.15.0",
         "googleapis": "^143.0.0",
-        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-html-reporter": "^3.10.2",
         "jest-junit": "^16.0.0",
@@ -2817,6 +2817,24 @@
       },
       "peerDependencies": {
         "jquery": "^3.6.0"
+      }
+    },
+    "node_modules/@ministryofjustice/hmpps-precommit-hooks": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-precommit-hooks/-/hmpps-precommit-hooks-0.0.2.tgz",
+      "integrity": "sha512-zTt1VxIdzhrY3srT/cCosyW8bTc9+afnAgbL647WkTAtUXfDAHu8mqNFf/2Ek5SulWojhx/oM7luJ2+htP9NFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "husky": "^9.1.7"
+      },
+      "bin": {
+        "hmpps-precommit-hooks": "bin/init.sh",
+        "hmpps-precommit-hooks-prepare": "bin/prepare.sh",
+        "test-secret-protection": "bin/test.sh"
+      },
+      "engines": {
+        "node": "20 || 22"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.9.1",
     "@google-cloud/local-auth": "^3.0.1",
-    "@ministryofjustice/hmpps-precommit-hooks": "^0.0.2",
+    "@ministryofjustice/hmpps-precommit-hooks": "^0.0.1",
     "@playwright/test": "^1.52.0",
     "@types/bunyan": "^1.8.11",
     "@types/bunyan-format": "^0.2.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:ministryofjustice/hmpps-resettlement-passport-person-on-probation-ui.git",
   "license": "MIT",
   "scripts": {
-    "prepare": "husky",
+    "prepare": "hmpps-precommit-hooks-prepare",
     "copy-views": "cp -R server/views dist/server/",
     "copy-views-watch": "rsync -ru server/views dist/server/",
     "compile-sass": "sass --quiet-deps --load-path=. --no-source-map assets/scss:./assets/stylesheets --style compressed",
@@ -36,7 +36,10 @@
     "end-to-end-test": "cucumber-js test --tags \"@test\"",
     "cms-test": "cucumber-js test --tags \"@cms\"",
     "install-security-test-requirements": "pip install -r ./security_test/requirements.txt",
-    "security-test": "python3 ./security_test/test_security.py"
+    "security-test": "python3 ./security_test/test_security.py",
+    "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml",
+    "precommit:lint": "node_modules/.bin/lint-staged",
+    "precommit:verify": "npm run typecheck && npm test"
   },
   "engines": {
     "node": "^20",
@@ -147,6 +150,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.9.1",
     "@google-cloud/local-auth": "^3.0.1",
+    "@ministryofjustice/hmpps-precommit-hooks": "^0.0.2",
     "@playwright/test": "^1.52.0",
     "@types/bunyan": "^1.8.11",
     "@types/bunyan-format": "^0.2.9",
@@ -187,7 +191,6 @@
     "eslint-plugin-prettier": "^5.4.0",
     "globals": "^15.15.0",
     "googleapis": "^143.0.0",
-    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-html-reporter": "^3.10.2",
     "jest-junit": "^16.0.0",


### PR DESCRIPTION
Install hmpps-precommit-hooks as per https://mojdt.slack.com/archives/C69NWE339/p1749647291374329, to enable secret scanning on new commits.  This means gitleaks will be run on every commit before it can be pushed to a branch, to check for any secrets. 
